### PR TITLE
Use relative paths to access resources

### DIFF
--- a/js/modules/services/d3.js
+++ b/js/modules/services/d3.js
@@ -31,7 +31,7 @@ angular.module('kubernetesApp.components.graph')
         var scriptTag = $document[0].createElement('script');
         scriptTag.type = 'text/javascript';
         scriptTag.async = true;
-        scriptTag.src = '/vendor/d3/d3.min.js';
+        scriptTag.src = 'vendor/d3/d3.min.js';
         scriptTag.onreadystatechange = function() {
           if (this.readyState == 'complete') onScriptLoad();
         };

--- a/js/modules/services/d3RenderingService.js
+++ b/js/modules/services/d3RenderingService.js
@@ -431,7 +431,7 @@
 
           d3.select(parentNode)
               .append('image')
-              .attr('xlink:href', function(d) { return '/components/graph/img/Pin.svg'; })
+              .attr('xlink:href', function(d) { return 'components/graph/img/Pin.svg'; })
               .attr('display', function(d) { return d.fixed & CONSTANTS.FIXED_PINNED_BIT ? '' : 'none'; })
               .attr('width', function(d) { return '13px'; })
               .attr('height', function(d) { return '13px'; });
@@ -927,7 +927,7 @@
           var singleImage = window.d3.select(this);
           var siblingText = window.d3.select(this.parentNode).select('text');
           var bbox = siblingText[0][0] ? siblingText[0][0].getBBox() : {width: 0};
-          var isPinIcon = singleImage.attr('xlink:href') === '/components/graph/img/Pin.svg';
+          var isPinIcon = singleImage.attr('xlink:href') === 'components/graph/img/Pin.svg';
 
           singleImage.attr('display', function(d) {
             if (isPinIcon) {

--- a/less/graph.less
+++ b/less/graph.less
@@ -110,7 +110,7 @@
 }
 
 .pin-cursor {
-  cursor: url(/components/graph/img/Pin.svg) 6 21, auto;
+  cursor: url(components/graph/img/Pin.svg) 6 21, auto;
 }
 
 .zoom-cursor {

--- a/manifest.json
+++ b/manifest.json
@@ -4,13 +4,13 @@
     {
       "description": "Force-directed graph visualization.",
       "url": "/",
-      "templateUrl": "/components/graph/pages/home.html"
+      "templateUrl": "components/graph/pages/home.html"
     },
     {
       "description": "Inspection panel with detailed information about Kubernetes cluster entities.",
       "url": "/inspect",
-      "templateUrl": "/components/graph/pages/inspect.html",
-      "css": "/components/graph/css/show-details-table.css"
+      "templateUrl": "components/graph/pages/inspect.html",
+      "css": "components/graph/css/show-details-table.css"
     }
   ]
 }


### PR DESCRIPTION
In kube-apiserver the UI is hosted under /static/app and all URIs
need to be relative to that.
